### PR TITLE
Add default array if config file doesn't exist

### DIFF
--- a/src/LogToDB.php
+++ b/src/LogToDB.php
@@ -49,7 +49,7 @@ class LogToDB
     function __construct($loggingConfig = [])
     {
         //Log default config if present
-        $this->config = $loggingConfig + config('logtodb');
+        $this->config = $loggingConfig + (config('logtodb') ?? []);
         $this->collection = $this->config['collection'] ?? 'log';
         $this->model = $this->config['model'] ?? null;
 


### PR DESCRIPTION
I got **Fatal error: Uncaught Error: Unsupported operand types when LogToDB.php doesn't exist**. if we don't need to provide other configurations or just want to check the package i think this might be useful.